### PR TITLE
Set OpenGL viewport

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -184,6 +184,11 @@ bool Client::initWindow(GLFWwindow*& window) {
 
     glfwMakeContextCurrent(window);
 
+    int width, height;
+
+    glfwGetFramebufferSize(window, &width, &height);
+    glViewport(0, 0, width, height);
+
     if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
         std::cerr << "Failed to initialize GLAD.\n";
         return false;


### PR DESCRIPTION
I just learned that GLFW does not auto-call glViewport() on Windows so I set OpenGL viewport.