### PR TITLE
Update disconnect handling to remove physics object, and add server-side game timer broadcast

### DIFF
--- a/include/client/client.hpp
+++ b/include/client/client.hpp
@@ -76,17 +76,30 @@ private:
     void receiveServerMessage();
 
     /**
-     * @brief Handles server messages containing player state updates.
+     * @brief Handles server messages from the server.
      * 
-     * Parses a JSON message of type "player_states" containing the positions and directions
-     * of all currently connected players. Updates each player's state in the local data structures,
+     * Parses a JSON message and dispatches it based on its "type" field.
+     * Supported message types:
+     * - "player_states": Updates player positions, directions, and handles disconnected players.
+     * - "time_left": Updates the game timer displayed on the client.
+     * 
+     * @param message A newline-terminated JSON string received from the server.
+     */
+    void handleServerMessage(const std::string& message);
+
+    /**
+     * @brief Updates the local player states based on server data.
+     * 
+     * Updates each player's state in the local data structures,
      * and sets the current client's camera position.
      * Also detects players who have disconnected, removes their data from local data structures,
      * and marks them for removal from the scene.
      * 
-     * @param message A newline-terminated JSON string received from the server.
+     * @param parsed A parsed JSON object containing player state information.
      */
-    void handleServerMessage(std::string message);
+    void updatePlayerStates(const nlohmann::json& parsed);
+
+    void updateGameTimer(const nlohmann::json& parsed);
 
     /**
      * @brief Toggles the mouse lock state when the Esc key is pressed.

--- a/include/server/server.hpp
+++ b/include/server/server.hpp
@@ -118,8 +118,21 @@ private:
      */
     void broadcastPlayerStates();
 
+    /**
+     * @brief Starts the game timer.
+     * 
+     * Begins ticking the server-side game timer, broadcasting the remaining time
+     * to all connected clients every second. This function is called once 4 clients
+     * are connected and continues running until all clients disconnect.
+     */
     void startGameTimer();
 
+    /**
+     * @brief Broadcasts the current time left to all clients.
+     * 
+     * Sends a JSON message containing the remaining game time (in minutes and seconds)
+     * to every connected client. Called once per second by the game timer loop.
+     */
     void broadcastTimeLeft();
 
     boost::asio::io_context ioContext;

--- a/include/server/server.hpp
+++ b/include/server/server.hpp
@@ -118,9 +118,18 @@ private:
      */
     void broadcastPlayerStates();
 
+    void startGameTimer();
+
+    void broadcastTimeLeft();
+
     boost::asio::io_context ioContext;
     boost::asio::ip::tcp::acceptor acceptor;
+
     boost::asio::steady_timer tickTimer;
+    boost::asio::steady_timer gameTimer;
+
+    bool hasTimerStarted;
+    int timeLeft;
 
     std::unordered_map<int, std::shared_ptr<boost::asio::ip::tcp::socket>> clients;
     std::unordered_map<int, boost::asio::streambuf> buffers;

--- a/include/shared/config.hpp
+++ b/include/shared/config.hpp
@@ -9,6 +9,8 @@ namespace config {
     inline constexpr int MAX_PLAYERS = 4;
     inline constexpr int TICK_RATE = 30;
 
+    inline constexpr int TOTAL_GAME_TIME = 600; // 10 mins
+
     inline constexpr float WORLD_WIDTH = 1600.0f;
     inline constexpr float WORLD_HEIGHT = 900.0f;
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -93,11 +93,13 @@ void Server::handleClientDisconnect(int clientId) {
     if (it != clients.end()) {
         it->second->close();
         clients.erase(it);
-        
-        players.erase(clientId);
-        
+
         buffers.erase(clientId);
         clientMessages.erase(clientId);
+
+        world.removeObject(&players[clientId]->getBody());
+        delete players[clientId];
+        players.erase(clientId);
 
         std::cout << "Client #" << clientId << " disconnected.\n";
     }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -12,7 +12,10 @@ using Clock = std::chrono::steady_clock;
 
 Server::Server()
     : acceptor(ioContext, tcp::endpoint(tcp::v4(), config::SERVER_PORT)),
-      tickTimer(ioContext) {}
+      tickTimer(ioContext),
+      gameTimer(ioContext),
+      hasTimerStarted(false),
+      timeLeft(config::TOTAL_GAME_TIME) {}
 
 Server::~Server() {}
 
@@ -85,6 +88,11 @@ void Server::handleClientJoin(int clientId) {
 
     // add player to physics world
     world.addObject(&(player->getBody()));
+
+    if (!hasTimerStarted && clients.size() == 4) {
+        hasTimerStarted = true;
+        startGameTimer();
+    }
 }
 
 void Server::handleClientDisconnect(int clientId) {
@@ -102,6 +110,12 @@ void Server::handleClientDisconnect(int clientId) {
         players.erase(clientId);
 
         std::cout << "Client #" << clientId << " disconnected.\n";
+    }
+
+    if (hasTimerStarted && clients.size() == 0) {
+        hasTimerStarted = false;
+        gameTimer.cancel();
+        timeLeft = config::TOTAL_GAME_TIME;
     }
 }
 
@@ -140,7 +154,6 @@ void Server::startTick() {
             handleClientMessages();
             handlePhysics();
             broadcastPlayerStates();
-
             startTick();
         }
     });
@@ -203,6 +216,38 @@ void Server::broadcastPlayerStates() {
         } catch (const std::exception& e) {
             handleClientDisconnect(clientId);
         }
+    }
+}
+
+void Server::startGameTimer() {
+    gameTimer.expires_after(std::chrono::seconds(1));
+    gameTimer.async_wait([this](const boost::system::error_code& ec) {
+        if (!ec) {
+            broadcastTimeLeft();
+            startGameTimer();
+        } else if (ec == boost::asio::error::operation_aborted) {
+            return;
+        }
+    });
+}
+
+void Server::broadcastTimeLeft() {
+    json message;
+    message["type"] = "time_left";
+    message["minutes"] = timeLeft / 60;
+    message["seconds"] = timeLeft % 60;
+    std::string packet = message.dump() + "\n";
+
+    for (const auto& [clientId, socket] : clients) {
+        try {
+            boost::asio::write(*socket, boost::asio::buffer(packet));
+        } catch (const std::exception& e) {
+            handleClientDisconnect(clientId);
+        }
+    }
+
+    if (timeLeft > 0) {
+        --timeLeft;
     }
 }
 


### PR DESCRIPTION
- Properly remove a player’s RigidBody from the world and call destructors on disconnect. This prevents invalid physics references after a player leaves.
- Add a server-side game timer. When 4 clients are connected, the timer starts ticking and broadcasts the remaining time to all clients every second. If a client disconnects, the timer continues running. When all clients disconnect, the timer stops and resets for the next round. It restarts automatically once 4 clients reconnect.