### PR TITLE
Make respawn relative

### DIFF
--- a/include/shared/config.hpp
+++ b/include/shared/config.hpp
@@ -87,7 +87,7 @@ inline constexpr glm::vec3 PARKOUR_OBJECT_POSITIONS[3] = {
 inline constexpr glm::vec3 PARKOUR_KEY_POSITION = {-8.0f, 6.0f, 8.0f};
 
 // Swamp Related Configs
-inline constexpr glm::vec3 SWAMP_RESPAWN = {21.0f, 1.0f, 0.0f};
+inline constexpr glm::vec3 SWAMP_RESPAWN = {1.0f, 1.0f, 0.0f};
 inline constexpr int SWAMP_NUM_ROWS = 8;
 
 inline constexpr int SWAMP_NUM_LILYPADS = 16; // Total
@@ -109,16 +109,15 @@ inline constexpr const char* JUMPLILYPAD = "{85da62c4-60ce-4776-b1f3-2503b761aa8
 inline constexpr const char* UNLOCKDOOR = "{008e7455-ae30-40ce-a197-5e85b67035b8}";
 inline constexpr const char* GRABKEY = "{f811c9cc-fec0-4714-8a32-e645ad8a502b}";
 
+// Audio for Set Volume
 
-//Audio for Set Volume 
-
-//Controlled by Client
+// Controlled by Client
 inline constexpr float SWAMP_AMBIENCE_VOL = 0.5f;
 inline constexpr float FOOTSTEPCARPET_VOL = 0.1f;
 
 inline constexpr int FOOTSTEP_COOLDOWN_RATE = 7;
 
-//Controlled by Server
+// Controlled by Server
 inline constexpr float SWAMP_AUDIO_FILE_VOL = 2.5f;
 inline constexpr float LILYPAD_VOL = 0.2f;
 inline constexpr float UNLOCKDOOR_VOL = 0.5f;

--- a/src/server/components/water.cpp
+++ b/src/server/components/water.cpp
@@ -28,5 +28,5 @@ void Water::customCollision(ICustomPhysics* otherObject) {
     playerBody.setForce(glm::vec3{0.0f, 0.0f, 0.0f});
     playerBody.setVelocity(glm::vec3{0.0f, 0.0f, 0.0f});
     // TODO: add offset for the individual player, so 2 players don't spawn into the same spot.
-    playerBody.setPosition(config::SWAMP_RESPAWN);
+    playerBody.setPosition(config::SWAMP_RESPAWN + config::SWAMP_ROOM_POSITION);
 }

--- a/src/server/swamp.cpp
+++ b/src/server/swamp.cpp
@@ -14,7 +14,7 @@ Swamp::Swamp(int roomID, World& worldRef, Server& serverRef)
     solution = config::SWAMP_SOLUTION;
     audioFile = config::SWAMP_AUDIO_FILE;
 
-    respawnPoint = config::SWAMP_RESPAWN;
+    respawnPoint = config::SWAMP_RESPAWN + config::SWAMP_ROOM_POSITION;
 }
 
 Swamp::~Swamp() {


### PR DESCRIPTION
Instead of hardcoding swamp respawn, make it relative to where the swamp room is. Old version spawned you into a room next to the lobby